### PR TITLE
Always use InvariantCulture when converting from/to floats

### DIFF
--- a/src_plugin/UI/InteractiveValues/InteractiveColor.cs
+++ b/src_plugin/UI/InteractiveValues/InteractiveColor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -32,20 +33,20 @@ namespace ConfigManager.UI.InteractiveValues
         {
             if (this.Value is Color32 c32)
             {
-                inputs[0].text = c32.r.ToString();
-                inputs[1].text = c32.g.ToString();
-                inputs[2].text = c32.b.ToString();
-                inputs[3].text = c32.a.ToString();
+                inputs[0].text = c32.r.ToString(CultureInfo.InvariantCulture);
+                inputs[1].text = c32.g.ToString(CultureInfo.InvariantCulture);
+                inputs[2].text = c32.b.ToString(CultureInfo.InvariantCulture);
+                inputs[3].text = c32.a.ToString(CultureInfo.InvariantCulture);
 
                 if (colorImage)
                     colorImage.color = c32;
             }
             else if (this.Value is Color color)
             {
-                inputs[0].text = color.r.ToString();
-                inputs[1].text = color.g.ToString();
-                inputs[2].text = color.b.ToString();
-                inputs[3].text = color.a.ToString();
+                inputs[0].text = color.r.ToString(CultureInfo.InvariantCulture);
+                inputs[1].text = color.g.ToString(CultureInfo.InvariantCulture);
+                inputs[2].text = color.b.ToString(CultureInfo.InvariantCulture);
+                inputs[3].text = color.a.ToString(CultureInfo.InvariantCulture);
 
                 if (colorImage)
                     colorImage.color = color;
@@ -110,13 +111,13 @@ namespace ConfigManager.UI.InteractiveValues
             {
                 if (Value is Color)
                 {
-                    float val = float.Parse(value);
+                    float val = float.Parse(value, CultureInfo.InvariantCulture);
                     SetValueToColor(val);
                     sliders[index].value = val;
                 }
                 else
                 {
-                    byte val = byte.Parse(value);
+                    byte val = byte.Parse(value, CultureInfo.InvariantCulture);
                     SetValueToColor32(val);
                     sliders[index].value = val;
                 }
@@ -150,9 +151,9 @@ namespace ConfigManager.UI.InteractiveValues
                     }
                     else
                     {
-                        inputField.Text = value.ToString();
+                        inputField.Text = value.ToString(CultureInfo.InvariantCulture);
                         SetValueToColor(value);
-                        inputs[index].text = value.ToString();
+                        inputs[index].text = value.ToString(CultureInfo.InvariantCulture);
                     }
                 }
                 catch (Exception ex)

--- a/src_plugin/UI/InteractiveValues/InteractiveFloatStruct.cs
+++ b/src_plugin/UI/InteractiveValues/InteractiveFloatStruct.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -48,7 +49,7 @@ namespace ConfigManager.UI.InteractiveValues
                     {
                         FieldInfo field = fields[i];
                         float val = (float)field.GetValue(instance);
-                        inputs[i].text = val.ToString();
+                        inputs[i].text = val.ToString(CultureInfo.InvariantCulture);
                     }
                 }
                 catch (Exception ex)
@@ -167,7 +168,7 @@ namespace ConfigManager.UI.InteractiveValues
                 {
                     try
                     {
-                        float f = float.Parse(val);
+                        float f = float.Parse(val, CultureInfo.InvariantCulture);
                         Value = structInfo.SetValue(ref this.Value, index, f);
                         Owner.SetValueFromIValue();
                     }


### PR DESCRIPTION
Fixes #15

I'm actually rather confused why the current code doesn't already work and just allows me to use `,` everywhere. After looking into it a bit, apparently, during the first call to `InteractiveNumber.RefreshUIForValue`, `CurrentCulture` is set to `de-DE` i.e. German as expected but on later calls to both it and `InteractiveNumber.SetValueFromInput`, it's unset. `CurrentUICulture` is always set to German though but it doesn't seem to impact whether a period or comma is used for parsing and printing.

So during the initial refresh, the input is set to `3,5` but then on all further calls it wants `3.5`.

Not really sure why this is, I guess apparently the culture is set per thread and maybe the other calls run in another thread where the culture isn't set or is reset for some reason?

I guess if you know why this happens, maybe you can find a better fix. Otherwise, the proposed changes work as expected though I guess it's a bit annoying to have to specify the culture everywhere and I guess is also a bit brittle since it's easy to forget but not sure there's a much better solution.